### PR TITLE
Adding Merger and Deleting Regex for yt-dlp parsing

### DIFF
--- a/lib/youtube_dl/output_parser.rb
+++ b/lib/youtube_dl/output_parser.rb
@@ -20,6 +20,15 @@ module YoutubeDL
         return :destination
       end
 
+      if m[:merger]
+        state.destination = Pathname(m[:merger])
+        return :merger
+      end
+
+      if m[:deleting]
+        return :deleting
+      end
+
       if m[:info_json]
         state.info_json = Pathname(m[:info_json]) if m[:info_json]
         return :info_json
@@ -53,6 +62,8 @@ module YoutubeDL
         #{progress_regex} |
         #{destination_regex} |
         #{existing_destination_regex} |
+        #{merger_regex} |
+        #{deletion_regex} | 
         #{info_json_regex} |
         #{error_regex}
       }x
@@ -85,6 +96,20 @@ module YoutubeDL
         \[download\] \s
         (?<destination>.*?) \s
         has \s already \s been \s downloaded
+      }x
+    end
+
+    def merger_regex
+      %r{
+        \[Merger\] \s+ Merging \s+ formats \s+ into \s+
+        "(?<merger>[^"]+)"
+      }x
+    end
+
+    def deletion_regex
+      %r{
+        Deleting \s+ original \s+ file \s+
+        (?<deleting>.*)
       }x
     end
 

--- a/lib/youtube_dl/state.rb
+++ b/lib/youtube_dl/state.rb
@@ -10,6 +10,8 @@ module YoutubeDL
       :error,
       :info_json,
       :info,
+      :merger,
+      :deleting,
     )
 
     def error?


### PR DESCRIPTION
Downloading certain links with `yt-dlp` result in a multiple file merging and deleting like the following:

```
yt-dlp --newline --no-color --write-info-json --no-playlist https://www.reddit.com/r/funnyvideos/comments/yrfmk9/sassy_girl/
[Reddit] Extracting URL: https://www.reddit.com/r/funnyvideos/comments/yrfmk9/sassy_girl/
[Reddit] yrfmk9: Downloading JSON metadata
[Reddit] yrfmk9: Downloading m3u8 information
[Reddit] yrfmk9: Downloading MPD manifest
[info] 6mliesp0o4z91: Downloading 1 format(s): hls-1541+dash-audio_0_132095
[info] Writing video metadata as JSON to: Sassy Girl [6mliesp0o4z91].info.json
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 8
[download] Destination: Sassy Girl [6mliesp0o4z91].fhls-1541.mp4
[download]   0.0% of ~   4.95MiB at      0.00B/s ETA Unknown (frag 0/8)
[download]   0.1% of ~   4.96MiB at      0.00B/s ETA Unknown (frag 0/8)
[download]   0.1% of ~   4.98MiB at      0.00B/s ETA Unknown (frag 0/8)
[download]   0.3% of ~   5.01MiB at      0.00B/s ETA Unknown (frag 0/8)
[download]   0.6% of ~   5.07MiB at      0.00B/s ETA Unknown (frag 0/8)
[download]   1.2% of ~   5.20MiB at  309.47KiB/s ETA Unknown (frag 0/8)
[download]   2.3% of ~   5.45MiB at  309.47KiB/s ETA Unknown (frag 0/8)
[download]   4.2% of ~   5.95MiB at  309.47KiB/s ETA Unknown (frag 0/8)
[download]   7.2% of ~   6.95MiB at    1.42MiB/s ETA Unknown (frag 0/8)
[download]   6.9% of ~   8.95MiB at    1.42MiB/s ETA Unknown (frag 0/8)
[download]   6.2% of ~   9.91MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  12.2% of ~   5.08MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  12.2% of ~   5.09MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  12.3% of ~   5.10MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  12.4% of ~   5.11MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  12.6% of ~   5.14MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  13.1% of ~   5.21MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  13.9% of ~   5.33MiB at    1.42MiB/s ETA Unknown (frag 1/8)
[download]  15.6% of ~   5.58MiB at    2.45MiB/s ETA Unknown (frag 1/8)
[download]  18.4% of ~   6.08MiB at    2.45MiB/s ETA Unknown (frag 1/8)
[download]  18.0% of ~   7.08MiB at    2.45MiB/s ETA Unknown (frag 1/8)
[download]  16.5% of ~   7.69MiB at    2.45MiB/s ETA Unknown (frag 2/8)
[download]  24.3% of ~   5.24MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  24.3% of ~   5.24MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  24.4% of ~   5.24MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  24.5% of ~   5.25MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  24.7% of ~   5.27MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  25.1% of ~   5.32MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  25.8% of ~   5.40MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  27.3% of ~   5.57MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  30.0% of ~   5.90MiB at    3.37MiB/s ETA Unknown (frag 2/8)
[download]  29.9% of ~   6.57MiB at    3.60MiB/s ETA Unknown (frag 2/8)
[download]  27.7% of ~   7.08MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  37.4% of ~   5.25MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  37.4% of ~   5.25MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  37.5% of ~   5.25MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  37.6% of ~   5.26MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  37.8% of ~   5.28MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  38.1% of ~   5.31MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  38.9% of ~   5.37MiB at    3.60MiB/s ETA Unknown (frag 3/8)
[download]  40.2% of ~   5.50MiB at    3.78MiB/s ETA Unknown (frag 3/8)
[download]  42.8% of ~   5.75MiB at    3.78MiB/s ETA Unknown (frag 3/8)
[download]  42.0% of ~   6.25MiB at    3.78MiB/s ETA Unknown (frag 3/8)
[download]  39.9% of ~   6.57MiB at    3.78MiB/s ETA Unknown (frag 4/8)
[download]  50.5% of ~   5.20MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  50.5% of ~   5.20MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  50.5% of ~   5.21MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  50.6% of ~   5.21MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  50.8% of ~   5.22MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  51.2% of ~   5.25MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  51.9% of ~   5.30MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  53.2% of ~   5.40MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  55.8% of ~   5.60MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  54.2% of ~   6.00MiB at    4.00MiB/s ETA Unknown (frag 4/8)
[download]  52.4% of ~   6.20MiB at    4.00MiB/s ETA Unknown (frag 5/8)
[download]  61.5% of ~   5.28MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  61.6% of ~   5.29MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  61.6% of ~   5.29MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  61.7% of ~   5.29MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  61.9% of ~   5.30MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  62.2% of ~   5.32MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  62.9% of ~   5.37MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  64.2% of ~   5.45MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  66.8% of ~   5.62MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  66.6% of ~   5.95MiB at    4.28MiB/s ETA Unknown (frag 5/8)
[download]  63.6% of ~   6.23MiB at    4.28MiB/s ETA Unknown (frag 6/8)
[download]  75.4% of ~   5.25MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  75.5% of ~   5.26MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  75.5% of ~   5.26MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  75.6% of ~   5.26MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  75.8% of ~   5.27MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  76.1% of ~   5.29MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  76.8% of ~   5.32MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  78.1% of ~   5.40MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  80.6% of ~   5.54MiB at    4.60MiB/s ETA Unknown (frag 6/8)
[download]  78.9% of ~   5.82MiB at    4.95MiB/s ETA Unknown (frag 6/8)
[download]  76.9% of ~   5.98MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  94.9% of ~   4.85MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  94.9% of ~   4.85MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  94.9% of ~   4.85MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  95.0% of ~   4.85MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  95.2% of ~   4.86MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  95.5% of ~   4.88MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  96.2% of ~   4.91MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  97.5% of ~   4.97MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  95.1% of ~   5.10MiB at    4.95MiB/s ETA Unknown (frag 7/8)
[download]  95.1% of ~   5.10MiB at    4.95MiB/s ETA Unknown (frag 8/8)
[download] 100% of    4.85MiB in 00:00:00 at 5.78MiB/s
[download] Destination: Sassy Girl [6mliesp0o4z91].fdash-audio_0_132095.m4a
[download]   0.2% of  473.79KiB at  381.68KiB/s ETA 00:01
[download]   0.6% of  473.79KiB at  899.94KiB/s ETA 00:00
[download]   1.5% of  473.79KiB at    1.75MiB/s ETA 00:00
[download]   3.2% of  473.79KiB at    3.26MiB/s ETA 00:00
[download]   6.5% of  473.79KiB at    4.38MiB/s ETA 00:00
[download]  13.3% of  473.79KiB at    8.05MiB/s ETA 00:00
[download]  26.8% of  473.79KiB at   11.83MiB/s ETA 00:00
[download]  53.8% of  473.79KiB at   11.54MiB/s ETA 00:00
[download] 100.0% of  473.79KiB at   12.35MiB/s ETA 00:00
[download] 100% of  473.79KiB in 00:00:00 at 8.43MiB/s
[Merger] Merging formats into "Sassy Girl [6mliesp0o4z91].mp4"
Deleting original file Sassy Girl [6mliesp0o4z91].fdash-audio_0_132095.m4a (pass -k to keep)
Deleting original file Sassy Girl [6mliesp0o4z91].fhls-1541.mp4 (pass -k to keep)
```

the `YoutubeDL.download(url).call` will download links like this although throws a `#<TypeError: no implicit conversion of Errno::EIO into String>` which is hidden `rescue Errno::EIO` https://github.com/maxhollmann/ruby-ytdl/blob/6c58339f9cea505618f657f251f3966fea07a7b0/lib/youtube_dl/runner.rb#L53 . The file downloads, but leaves the `<filename>.info.json` that would have been cleaned up by `YoutubeDL`, but is not deleted because of the silenced error. 

This MR adds regex patterns for the merger and deleting lines for the parser such that the parser does not error out while listening to the `yt-dlp` process.

I didn't add this to the MR, but it may be good to warn or log the error instead of rescuing directly. 

```
rescue Errno::EIO => e
  puts "Errno:EIO error, but this probably just means " + e
end
```